### PR TITLE
doc(spitwindow): exec command in the splitted window

### DIFF
--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -383,6 +383,11 @@ unbind C-b
 set -g prefix 'M-`'
 bind 'M-`' send-prefix
 
+# split current window horizontally and exec command in the new window
+#bind - split-window -v "source /root/guanzenghui/.mysrc"
+# split current window vertically and exec command in the new window
+#bind _ split-window -h "source /root/guanzenghui/.mysrc"
+
 # if you don't want Oh my tmux! to alter a binding, use #!important
 # bind c new-window -c '#{pane_current_path}' #!important
 


### PR DESCRIPTION
添加注释，说明如何在执行 split 时，在新窗口中执行用户提供的命令。

**注意：如果命令执行失败，那么窗口将无法切分。**